### PR TITLE
adds readmes to free5gc charts

### DIFF
--- a/charts/free5gc-amf/README.md
+++ b/charts/free5gc-amf/README.md
@@ -1,0 +1,151 @@
+# free5gc-amf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC AMF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.amfName | string | `"AMF"` |  |
+| config.logger.level | string | `"info"` |  |
+| config.networkName.full | string | `"Gradiant5G"` |  |
+| config.networkName.short | string | `"G5G"` |  |
+| config.ngapIpList | string | `""` |  |
+| config.nrfUri | string | `""` |  |
+| config.plmnSupportList[0].plmnId.mcc | int | `999` |  |
+| config.plmnSupportList[0].plmnId.mnc | int | `70` |  |
+| config.plmnSupportList[0].snssaiList[0].sd | string | `"ffffff"` |  |
+| config.plmnSupportList[0].snssaiList[0].sst | int | `1` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| config.servedGuamiList[0].amfId | string | `"cafe00"` |  |
+| config.servedGuamiList[0].plmnId.mcc | int | `999` |  |
+| config.servedGuamiList[0].plmnId.mnc | int | `70` |  |
+| config.supportDnnList[0] | string | `"internet"` |  |
+| config.supportTaiList[0].plmnId.mcc | int | `999` |  |
+| config.supportTaiList[0].plmnId.mnc | int | `70` |  |
+| config.supportTaiList[0].tac | string | `"000001"` |  |
+| containerPorts.ngap | int | `38412` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/amf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.ngap.annotations | object | `{}` |  |
+| services.ngap.clusterIP | string | `""` |  |
+| services.ngap.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.ngap.extraPorts | list | `[]` |  |
+| services.ngap.loadBalancerIP | string | `""` |  |
+| services.ngap.loadBalancerSourceRanges | list | `[]` |  |
+| services.ngap.nodePorts.ngap | string | `""` |  |
+| services.ngap.ports.ngap | int | `38412` |  |
+| services.ngap.sessionAffinity | string | `"None"` |  |
+| services.ngap.sessionAffinityConfig | object | `{}` |  |
+| services.ngap.type | string | `"ClusterIP"` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-ausf/README.md
+++ b/charts/free5gc-ausf/README.md
@@ -1,0 +1,126 @@
+# free5gc-ausf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC AUSF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.nrfUri | string | `""` |  |
+| config.plmnSupportList[0].mcc | int | `999` |  |
+| config.plmnSupportList[0].mnc | int | `70` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/ausf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-chf/README.md
+++ b/charts/free5gc-chf/README.md
@@ -1,0 +1,126 @@
+# free5gc-chf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC CHF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.cgf.hostIPv4 | string | `""` |  |
+| config.logger.level | string | `"info"` |  |
+| config.mongodb.url | string | `""` |  |
+| config.nrfUri | string | `""` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/chf"` |  |
+| image.tag | string | `"latest"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-nrf/README.md
+++ b/charts/free5gc-nrf/README.md
@@ -1,0 +1,126 @@
+# free5gc-nrf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC NRF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.DefaultPlmnId.mcc | int | `999` |  |
+| config.DefaultPlmnId.mnc | int | `70` |  |
+| config.MongoDBUrl | string | `""` |  |
+| config.logger.level | string | `"info"` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/nrf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-nssf/README.md
+++ b/charts/free5gc-nssf/README.md
@@ -1,0 +1,135 @@
+# free5gc-nssf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC NSSF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.nrfUri | string | `""` |  |
+| config.nsiList[0].nsiInformationList[0].nrfId | string | `"http://free5gc-nrf-sbi:8000/nnrf-nfm/v1/nf-instances"` |  |
+| config.nsiList[0].nsiInformationList[0].nsiId | int | `10` |  |
+| config.nsiList[0].snssai.sd | string | `"ffffff"` |  |
+| config.nsiList[0].snssai.sst | int | `1` |  |
+| config.nssfName | string | `"NSSF"` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| config.supportedNssaiInPlmnList[0].plmnId.mcc | int | `999` |  |
+| config.supportedNssaiInPlmnList[0].plmnId.mnc | int | `70` |  |
+| config.supportedNssaiInPlmnList[0].supportedSnssaiList[0].sd | string | `"ffffff"` |  |
+| config.supportedNssaiInPlmnList[0].supportedSnssaiList[0].sst | int | `1` |  |
+| config.supportedPlmnList[0].mcc | int | `999` |  |
+| config.supportedPlmnList[0].mnc | int | `70` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/nssf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-pcf/README.md
+++ b/charts/free5gc-pcf/README.md
@@ -1,0 +1,126 @@
+# free5gc-pcf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC PCF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.mongodb.url | string | `""` |  |
+| config.nrfUri | string | `""` |  |
+| config.pcfName | string | `"PCF"` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/pcf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-smf/README.md
+++ b/charts/free5gc-smf/README.md
@@ -1,0 +1,156 @@
+# free5gc-smf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC SMF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.nrfUri | string | `""` |  |
+| config.pfcp.externalAddr | string | `""` |  |
+| config.pfcp.listenAddr | string | `""` |  |
+| config.pfcp.nodeID | string | `""` |  |
+| config.plmnList[0].mcc | int | `999` |  |
+| config.plmnList[0].mnc | int | `70` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| config.smfName | string | `"SMF"` |  |
+| config.snssaiInfos[0].dnnInfos[0].dnn | string | `"internet"` |  |
+| config.snssaiInfos[0].dnnInfos[0].dns.ipv4 | string | `"8.8.8.8"` |  |
+| config.snssaiInfos[0].dnnInfos[0].dns.ipv6 | string | `"2001:4860:4860::8888"` |  |
+| config.snssaiInfos[0].sNssai.sd | string | `"ffffff"` |  |
+| config.snssaiInfos[0].sNssai.sst | int | `1` |  |
+| config.userplaneInformation.upNodes.UPF.addr | string | `""` |  |
+| config.userplaneInformation.upNodes.UPF.interfaces.endpoints | string | `""` |  |
+| config.userplaneInformation.upNodes.UPF.interfaces.networkInstances | string | `"internet"` |  |
+| config.userplaneInformation.upNodes.UPF.nodeID | string | `""` |  |
+| config.userplaneInformation.upNodes.UPF.sNssaiUpfInfos[0].dnnUpfInfoList[0].dnn | string | `"internet"` |  |
+| config.userplaneInformation.upNodes.UPF.sNssaiUpfInfos[0].dnnUpfInfoList[0].pools[0].cidr | string | `"10.60.0.0/16"` |  |
+| config.userplaneInformation.upNodes.UPF.sNssaiUpfInfos[0].dnnUpfInfoList[0].staticPools[0].cidr | string | `"10.60.100.0/24"` |  |
+| config.userplaneInformation.upNodes.UPF.sNssaiUpfInfos[0].sNssai.sd | string | `"ffffff"` |  |
+| config.userplaneInformation.upNodes.UPF.sNssaiUpfInfos[0].sNssai.sst | int | `1` |  |
+| containerPorts.pfcp | int | `8805` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/smf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.pfcp.annotations | object | `{}` |  |
+| services.pfcp.clusterIP | string | `""` |  |
+| services.pfcp.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.pfcp.extraPorts | list | `[]` |  |
+| services.pfcp.loadBalancerIP | string | `""` |  |
+| services.pfcp.loadBalancerSourceRanges | list | `[]` |  |
+| services.pfcp.nodePorts.pfcp | string | `""` |  |
+| services.pfcp.ports.pfcp | int | `8805` |  |
+| services.pfcp.sessionAffinity | string | `"None"` |  |
+| services.pfcp.sessionAffinityConfig | object | `{}` |  |
+| services.pfcp.type | string | `"ClusterIP"` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-udm/README.md
+++ b/charts/free5gc-udm/README.md
@@ -1,0 +1,124 @@
+# free5gc-udm
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC UDM service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.nrfUri | string | `""` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/udm"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-udr/README.md
+++ b/charts/free5gc-udr/README.md
@@ -1,0 +1,125 @@
+# free5gc-udr
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC UDR service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.logger.level | string | `"info"` |  |
+| config.mongodb.url | string | `""` |  |
+| config.nrfUri | string | `""` |  |
+| config.sbi.bindingIPv4 | string | `""` |  |
+| config.sbi.registerIPv4 | string | `""` |  |
+| containerPorts.sbi | int | `8000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/udr"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.sbi.annotations | object | `{}` |  |
+| services.sbi.clusterIP | string | `""` |  |
+| services.sbi.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.sbi.extraPorts | list | `[]` |  |
+| services.sbi.loadBalancerIP | string | `""` |  |
+| services.sbi.loadBalancerSourceRanges | list | `[]` |  |
+| services.sbi.nodePorts.sbi | string | `""` |  |
+| services.sbi.ports.sbi | int | `8000` |  |
+| services.sbi.sessionAffinity | string | `"None"` |  |
+| services.sbi.sessionAffinityConfig | object | `{}` |  |
+| services.sbi.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-upf/README.md
+++ b/charts/free5gc-upf/README.md
@@ -1,0 +1,138 @@
+# free5gc-upf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC UPF service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.dnnList[0].cidr | string | `"10.60.0.0/24"` |  |
+| config.dnnList[0].dnn | string | `"internet"` |  |
+| config.gtpu.ifList.name | string | `""` |  |
+| config.logger.level | string | `"info"` |  |
+| config.pfcp.addr | string | `""` |  |
+| config.pfcp.nodeID | string | `""` |  |
+| containerPorts.gtpu | int | `2152` |  |
+| containerPorts.pfcp | int | `8805` |  |
+| containerSecurityContext.capabilities.add[0] | string | `"NET_ADMIN"` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.privileged | bool | `true` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/upf"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector."kubernetes.io/hostname" | string | `"solidsnake"` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.gtpu.annotations | object | `{}` |  |
+| services.gtpu.clusterIP | string | `""` |  |
+| services.gtpu.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.gtpu.extraPorts | list | `[]` |  |
+| services.gtpu.loadBalancerIP | string | `""` |  |
+| services.gtpu.loadBalancerSourceRanges | list | `[]` |  |
+| services.gtpu.nodePorts.gtpu | string | `""` |  |
+| services.gtpu.ports.gtpu | int | `2152` |  |
+| services.gtpu.sessionAffinity | string | `"None"` |  |
+| services.gtpu.sessionAffinityConfig | object | `{}` |  |
+| services.gtpu.type | string | `"ClusterIP"` |  |
+| services.pfcp.annotations | object | `{}` |  |
+| services.pfcp.clusterIP | string | `""` |  |
+| services.pfcp.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.pfcp.extraPorts | list | `[]` |  |
+| services.pfcp.loadBalancerIP | string | `""` |  |
+| services.pfcp.loadBalancerSourceRanges | list | `[]` |  |
+| services.pfcp.nodePorts.pfcp | string | `""` |  |
+| services.pfcp.ports.pfcp | int | `8805` |  |
+| services.pfcp.sessionAffinity | string | `"None"` |  |
+| services.pfcp.sessionAffinityConfig | object | `{}` |  |
+| services.pfcp.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc-webui/README.md
+++ b/charts/free5gc-webui/README.md
@@ -1,0 +1,136 @@
+# free5gc-webui
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC WEBUI service on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| args | list | `[]` |  |
+| command | list | `[]` |  |
+| commonAnnotations | object | `{}` |  |
+| commonLabels | object | `{}` |  |
+| config.billingServer.hostIPv4 | string | `""` |  |
+| config.logger.level | string | `"info"` |  |
+| config.mongodb.url | string | `""` |  |
+| containerPorts.http | int | `5000` |  |
+| containerSecurityContext.enabled | bool | `true` |  |
+| containerSecurityContext.runAsNonRoot | bool | `true` |  |
+| containerSecurityContext.runAsUser | int | `1001` |  |
+| customLivenessProbe | object | `{}` |  |
+| customReadinessProbe | object | `{}` |  |
+| customStartupProbe | object | `{}` |  |
+| extraDeploy | list | `[]` |  |
+| extraEnvVarsCM | string | `""` |  |
+| extraEnvVarsSecret | string | `""` |  |
+| extraEnvVars[0].name | string | `"GIN_MODE"` |  |
+| extraEnvVars[0].value | string | `"release"` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| global.imagePullSecrets | list | `[]` |  |
+| global.imageRegistry | string | `""` |  |
+| global.storageClass | string | `""` |  |
+| hostAliases | list | `[]` |  |
+| image.debug | bool | `false` |  |
+| image.digest | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.pullSecrets | list | `[]` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"free5gc/webui"` |  |
+| image.tag | string | `"v3.3.0"` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.apiVersion | string | `""` |  |
+| ingress.enabled | bool | `true` |  |
+| ingress.extraHosts | list | `[]` |  |
+| ingress.extraPaths | list | `[]` |  |
+| ingress.extraRules | list | `[]` |  |
+| ingress.extraTls | list | `[]` |  |
+| ingress.hostname | string | `""` |  |
+| ingress.ingressClassName | string | `""` |  |
+| ingress.path | string | `"/"` |  |
+| ingress.pathType | string | `"ImplementationSpecific"` |  |
+| ingress.secrets | list | `[]` |  |
+| ingress.tls | bool | `false` |  |
+| initContainers | list | `[]` |  |
+| kubeVersion | string | `""` |  |
+| lifecycleHooks | object | `{}` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `5` |  |
+| livenessProbe.initialDelaySeconds | int | `600` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| namespaceOverride | string | `""` |  |
+| nodeAffinityPreset.key | string | `""` |  |
+| nodeAffinityPreset.type | string | `""` |  |
+| nodeAffinityPreset.values | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAffinityPreset | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podAntiAffinityPreset | string | `"soft"` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
+| podSecurityContext.fsGroup | int | `1001` |  |
+| priorityClassName | string | `""` |  |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `5` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `5` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` |  |
+| resources.limits | object | `{}` |  |
+| resources.requests | object | `{}` |  |
+| schedulerName | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automountServiceAccountToken | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| services.http.annotations | object | `{}` |  |
+| services.http.clusterIP | string | `""` |  |
+| services.http.externalTrafficPolicy | string | `"Cluster"` |  |
+| services.http.extraPorts | list | `[]` |  |
+| services.http.loadBalancerIP | string | `""` |  |
+| services.http.loadBalancerSourceRanges | list | `[]` |  |
+| services.http.nodePorts.http | string | `""` |  |
+| services.http.ports.http | int | `5000` |  |
+| services.http.sessionAffinity | string | `"None"` |  |
+| services.http.sessionAffinityConfig | object | `{}` |  |
+| services.http.type | string | `"ClusterIP"` |  |
+| sessionAffinity | string | `"None"` |  |
+| sidecars | list | `[]` |  |
+| startupProbe.enabled | bool | `false` |  |
+| startupProbe.failureThreshold | int | `5` |  |
+| startupProbe.initialDelaySeconds | int | `600` |  |
+| startupProbe.path | string | `"/"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.successThreshold | int | `1` |  |
+| startupProbe.timeoutSeconds | int | `5` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+

--- a/charts/free5gc/Chart.yaml
+++ b/charts/free5gc/Chart.yaml
@@ -44,11 +44,6 @@ dependencies:
     repository: file://../free5gc-chf
     condition: chf.enabled
     alias: chf
-  - name: free5gc-n3iwf
-    version: ~0.1.0
-    repository: file://../free5gc-n3iwf
-    condition: n3iwf.enabled
-    alias: n3iwf
   - name: free5gc-nrf
     version: ~0.1.0
     repository: file://../free5gc-nrf

--- a/charts/free5gc/README.md
+++ b/charts/free5gc/README.md
@@ -1,0 +1,55 @@
+# free5gc
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![AppVersion: 3.3.0](https://img.shields.io/badge/AppVersion-3.3.0-informational?style=flat-square)
+
+Helm chart to deploy Free5GC services on Kubernetes.
+
+**Homepage:** <https://github.com/gradiant/5g-charts>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| cgiraldo | <cgiraldo@gradiant.org> |  |
+| avrodriguez | <avrodriguez@gradiant.org> |  |
+
+## Source Code
+
+* <http://free5gc.org>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../free5gc-amf | amf(free5gc-amf) | ~0.1.0 |
+| file://../free5gc-ausf | ausf(free5gc-ausf) | ~0.1.0 |
+| file://../free5gc-chf | chf(free5gc-chf) | ~0.1.0 |
+| file://../free5gc-nrf | nrf(free5gc-nrf) | ~0.1.0 |
+| file://../free5gc-nssf | nssf(free5gc-nssf) | ~0.1.0 |
+| file://../free5gc-pcf | pcf(free5gc-pcf) | ~0.1.0 |
+| file://../free5gc-smf | smf(free5gc-smf) | ~0.1.0 |
+| file://../free5gc-udm | udm(free5gc-udm) | ~0.1.0 |
+| file://../free5gc-udr | udr(free5gc-udr) | ~0.1.0 |
+| file://../free5gc-upf | upf(free5gc-upf) | ~0.1.0 |
+| file://../free5gc-webui | webui(free5gc-webui) | ~0.1.0 |
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| amf.enabled | bool | `true` |  |
+| ausf.enabled | bool | `true` |  |
+| chf.enabled | bool | `true` |  |
+| mongodb.auth.enabled | bool | `false` |  |
+| mongodb.enabled | bool | `true` |  |
+| nrf.enabled | bool | `true` |  |
+| nssf.enabled | bool | `true` |  |
+| pcf.enabled | bool | `true` |  |
+| smf.enabled | bool | `true` |  |
+| udm.enabled | bool | `true` |  |
+| udr.enabled | bool | `true` |  |
+| upf.enabled | bool | `true` |  |
+| webui.enabled | bool | `true` |  |
+


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
documentation
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
Adds READMEs to free5gc charts

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
