### PR TITLE
adds advertise field to open5gs-upf chart

### DIFF
--- a/charts/open5gs-upf/Chart.yaml
+++ b/charts/open5gs-upf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-upf
-version: 2.2.0
+version: 2.2.1
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-upf/resources/config/upf.yaml
+++ b/charts/open5gs-upf/resources/config/upf.yaml
@@ -17,6 +17,9 @@ upf:
   gtpu:
     server:
     - dev: {{ default "eth0" .Values.config.upf.gtpu.dev }}
+      {{- if .Values.config.upf.gtpu.advertise }}
+      advertise: "{{ tpl .Values.config.upf.gtpu.advertise . }}"
+      {{- end }}
   session:
     {{- range .Values.config.subnetList }}
     - {{- omit . "createDev" "enableNAT" | toYaml | nindent 6 }}

--- a/charts/open5gs-upf/values.yaml
+++ b/charts/open5gs-upf/values.yaml
@@ -81,6 +81,7 @@ config:
   upf:
     gtpu:
       dev: ""
+      advertise: ""
   subnetList:
     - subnet: 10.45.0.1/16
       dnn: internet

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.2.0
+version: 2.2.1
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs/scp-values.yaml
+++ b/charts/open5gs/scp-values.yaml
@@ -7,7 +7,9 @@ populate:
     repository: gradiant/open5gs-dbctl
     tag: 0.10.3
     pullPolicy: IfNotPresent
-  initCommands: []
+  initCommands:
+  - open5gs-dbctl add_ue_with_slice 999700000000001 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA internet 1 111111
+  - open5gs-dbctl add_ue_with_slice 999700000000002 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA internet 1 111111
   # example of initCommands:
   #  - open5gs-dbctl add 999700000000001 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA
   #  - open5gs-dbctl add_ue_with_apn 999700000000002 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA internet
@@ -126,9 +128,3 @@ scp:
   enabled: true
   mongodb:
     enabled: false
-
-populate:
-  enabled: true
-  initCommands:
-  - open5gs-dbctl add_ue_with_slice 999700000000001 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA internet 1 111111
-  - open5gs-dbctl add_ue_with_slice 999700000000002 465B5CE8B199B49FAA5F0A2EE238A6BC E8ED289DEBA952E4283B54E88E6183CA internet 1 111111


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
bug
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
There was not advertise field in GTPU interface of Open5GS UPF. This PR fixes this.

#### Which issue(s) this PR fixes:
#167 

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
