### PR TITLE
adds possibility to change PLMN in NRF

### DIFF
--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.2.0
+version: 2.2.1
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nrf/resources/config/nrf.yaml
+++ b/charts/open5gs-nrf/resources/config/nrf.yaml
@@ -9,9 +9,9 @@ global:
 
 nrf:
   serving: # 5G roaming requires PLMN in NRF
-  - plmn_id:
-      mcc: 999
-      mnc: 70
+    {{- range .Values.config.servingList }}
+    - {{- toYaml . | nindent 6 }}
+    {{- end }}
   sbi:
     server:
     - dev: eth0

--- a/charts/open5gs-nrf/values.yaml
+++ b/charts/open5gs-nrf/values.yaml
@@ -77,6 +77,11 @@ image:
 
 config:
   logLevel: info
+  servingList:
+    - plmn_id:
+        mcc: 999
+        mnc: 70
+
 ## @param customOpen5gsConfig overwrite open5gs configuration file
 customOpen5gsConfig: {}
 

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.2.1
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
bug
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
It adds possibility to change PLMN in NRF, as it was a feature in last version of Open5GS

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
