### PR TITLE
Config hash added

### DIFF
--- a/charts/open5gs-amf/Chart.yaml
+++ b/charts/open5gs-amf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-amf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-amf/templates/deployment.yaml
+++ b/charts/open5gs-amf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-ausf/Chart.yaml
+++ b/charts/open5gs-ausf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-ausf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-ausf/templates/deployment.yaml
+++ b/charts/open5gs-ausf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-bsf/Chart.yaml
+++ b/charts/open5gs-bsf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-bsf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-bsf/templates/deployment.yaml
+++ b/charts/open5gs-bsf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-hss/Chart.yaml
+++ b/charts/open5gs-hss/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-hss
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-hss/templates/deployment.yaml
+++ b/charts/open5gs-hss/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-mme/Chart.yaml
+++ b/charts/open5gs-mme/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-mme
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-mme/templates/deployment.yaml
+++ b/charts/open5gs-mme/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.2.1
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nrf/templates/deployment.yaml
+++ b/charts/open5gs-nrf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-nssf/Chart.yaml
+++ b/charts/open5gs-nssf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nssf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nssf/templates/deployment.yaml
+++ b/charts/open5gs-nssf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-pcf/Chart.yaml
+++ b/charts/open5gs-pcf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcf/templates/deployment.yaml
+++ b/charts/open5gs-pcf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-pcrf/Chart.yaml
+++ b/charts/open5gs-pcrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcrf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcrf/templates/deployment.yaml
+++ b/charts/open5gs-pcrf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-scp/Chart.yaml
+++ b/charts/open5gs-scp/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-scp
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-scp/templates/deployment.yaml
+++ b/charts/open5gs-scp/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-sgwc/Chart.yaml
+++ b/charts/open5gs-sgwc/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwc
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwc/templates/deployment.yaml
+++ b/charts/open5gs-sgwc/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-sgwu/Chart.yaml
+++ b/charts/open5gs-sgwu/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwu
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwu/templates/deployment.yaml
+++ b/charts/open5gs-sgwu/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-smf/Chart.yaml
+++ b/charts/open5gs-smf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-smf
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-smf/templates/deployment.yaml
+++ b/charts/open5gs-smf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-udm/Chart.yaml
+++ b/charts/open5gs-udm/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udm
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udm/templates/deployment.yaml
+++ b/charts/open5gs-udm/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-udr/Chart.yaml
+++ b/charts/open5gs-udr/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udr
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udr/templates/deployment.yaml
+++ b/charts/open5gs-udr/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-upf/Chart.yaml
+++ b/charts/open5gs-upf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-upf
-version: 2.2.1
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-upf/templates/deployment.yaml
+++ b/charts/open5gs-upf/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/open5gs-webui/Chart.yaml
+++ b/charts/open5gs-webui/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 - email: avrodriguez@gradiant.org
   name: avrodriguez
 name: open5gs-webui
-version: 2.2.0
+version: 2.2.2
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-webui/templates/deployment.yaml
+++ b/charts/open5gs-webui/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
+        config-hash: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
Feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
It adds a config hash to the open5gs-x charts, enabling the 'helm upgrade' command to detect internal configuration changes. This is necessary because Helm only detects changes in the deployment specs, not in the injected ConfigMaps (those containing the configuration parameters).

