### PR TITLE
Upf configuration modified to use the non root image

### DIFF
--- a/charts/open5gs-amf/Chart.yaml
+++ b/charts/open5gs-amf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-amf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-ausf/Chart.yaml
+++ b/charts/open5gs-ausf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-ausf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-bsf/Chart.yaml
+++ b/charts/open5gs-bsf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-bsf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-hss/Chart.yaml
+++ b/charts/open5gs-hss/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-hss
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-mme/Chart.yaml
+++ b/charts/open5gs-mme/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-mme
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nssf/Chart.yaml
+++ b/charts/open5gs-nssf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nssf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcf/Chart.yaml
+++ b/charts/open5gs-pcf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcrf/Chart.yaml
+++ b/charts/open5gs-pcrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcrf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-scp/Chart.yaml
+++ b/charts/open5gs-scp/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-scp
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwc/Chart.yaml
+++ b/charts/open5gs-sgwc/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwc
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwu/Chart.yaml
+++ b/charts/open5gs-sgwu/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwu
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-smf/Chart.yaml
+++ b/charts/open5gs-smf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-smf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udm/Chart.yaml
+++ b/charts/open5gs-udm/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udm
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udr/Chart.yaml
+++ b/charts/open5gs-udr/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udr
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-upf/Chart.yaml
+++ b/charts/open5gs-upf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-upf
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-upf/templates/deployment.yaml
+++ b/charts/open5gs-upf/templates/deployment.yaml
@@ -73,6 +73,9 @@ spec:
             - "/k8s-entrypoint.sh"
           securityContext:
             privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
             capabilities:
               add: ["NET_ADMIN"]
           volumeMounts:

--- a/charts/open5gs-webui/Chart.yaml
+++ b/charts/open5gs-webui/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 - email: avrodriguez@gradiant.org
   name: avrodriguez
 name: open5gs-webui
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.2.3
+version: 2.2.4
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -29,87 +29,87 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: open5gs-amf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-amf
     condition: amf.enabled
     alias: amf
   - name: open5gs-ausf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-ausf
     condition: ausf.enabled
     alias: ausf
   - name: open5gs-bsf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-bsf
     condition: bsf.enabled
     alias: bsf
   - name: open5gs-hss
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-hss
     condition: hss.enabled
     alias: hss
   - name: open5gs-mme
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-mme
     condition: mme.enabled
     alias: mme
   - name: open5gs-nrf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-nrf
     condition: nrf.enabled
     alias: nrf
   - name: open5gs-nssf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-nssf
     condition: nssf.enabled
     alias: nssf
   - name: open5gs-pcf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-pcf
     condition: pcf.enabled
     alias: pcf
   - name: open5gs-pcrf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-pcrf
     condition: pcrf.enabled
     alias: pcrf
   - name: open5gs-scp
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-scp
     condition: scp.enabled
     alias: scp
   - name: open5gs-sgwc
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-sgwc
     condition: sgwc.enabled
     alias: sgwc
   - name: open5gs-sgwu
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-sgwu
     condition: sgwu.enabled
     alias: sgwu
   - name: open5gs-smf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-smf
     condition: smf.enabled
     alias: smf
   - name: open5gs-udm
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-udm
     condition: udm.enabled
     alias: udm
   - name: open5gs-udr
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-udr
     condition: udr.enabled
     alias: udr
   - name: open5gs-upf
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-upf
     condition: upf.enabled
     alias: upf
   - name: open5gs-webui
-    version: ~2.2.3
+    version: ~2.2.4
     repository: file://../open5gs-webui
     condition: webui.enabled
     alias: webui

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -29,87 +29,87 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: open5gs-amf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-amf
     condition: amf.enabled
     alias: amf
   - name: open5gs-ausf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-ausf
     condition: ausf.enabled
     alias: ausf
   - name: open5gs-bsf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-bsf
     condition: bsf.enabled
     alias: bsf
   - name: open5gs-hss
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-hss
     condition: hss.enabled
     alias: hss
   - name: open5gs-mme
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-mme
     condition: mme.enabled
     alias: mme
   - name: open5gs-nrf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-nrf
     condition: nrf.enabled
     alias: nrf
   - name: open5gs-nssf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-nssf
     condition: nssf.enabled
     alias: nssf
   - name: open5gs-pcf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-pcf
     condition: pcf.enabled
     alias: pcf
   - name: open5gs-pcrf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-pcrf
     condition: pcrf.enabled
     alias: pcrf
   - name: open5gs-scp
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-scp
     condition: scp.enabled
     alias: scp
   - name: open5gs-sgwc
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-sgwc
     condition: sgwc.enabled
     alias: sgwc
   - name: open5gs-sgwu
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-sgwu
     condition: sgwu.enabled
     alias: sgwu
   - name: open5gs-smf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-smf
     condition: smf.enabled
     alias: smf
   - name: open5gs-udm
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-udm
     condition: udm.enabled
     alias: udm
   - name: open5gs-udr
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-udr
     condition: udr.enabled
     alias: udr
   - name: open5gs-upf
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-upf
     condition: upf.enabled
     alias: upf
   - name: open5gs-webui
-    version: ~2.2.0
+    version: ~2.2.3
     repository: file://../open5gs-webui
     condition: webui.enabled
     alias: webui


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
Feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:

It modifies the deployment of the upf chart to use the non root open5gs image.