### PR TITLE
add nindent for customOpen5gsConfig

### DIFF
--- a/charts/open5gs-amf/templates/configmap.yaml
+++ b/charts/open5gs-amf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   amf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4  }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/amf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-ausf/templates/configmap.yaml
+++ b/charts/open5gs-ausf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   ausf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/ausf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-bsf/templates/configmap.yaml
+++ b/charts/open5gs-bsf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   bsf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/bsf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-hss/templates/configmap.yaml
+++ b/charts/open5gs-hss/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   hss.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/hss.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-mme/templates/configmap.yaml
+++ b/charts/open5gs-mme/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   mme.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/mme.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-nrf/templates/configmap.yaml
+++ b/charts/open5gs-nrf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   nrf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/nrf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-nssf/templates/configmap.yaml
+++ b/charts/open5gs-nssf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   nssf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/nssf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-pcf/templates/configmap.yaml
+++ b/charts/open5gs-pcf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   pcf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/pcf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-pcrf/templates/configmap.yaml
+++ b/charts/open5gs-pcrf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   pcrf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/pcrf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-scp/templates/configmap.yaml
+++ b/charts/open5gs-scp/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   scp.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/scp.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-sgwc/templates/configmap.yaml
+++ b/charts/open5gs-sgwc/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   sgwc.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/sgwc.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-sgwu/templates/configmap.yaml
+++ b/charts/open5gs-sgwu/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   sgwu.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/sgwu.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-smf/templates/configmap.yaml
+++ b/charts/open5gs-smf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   smf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/smf.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-udm/templates/configmap.yaml
+++ b/charts/open5gs-udm/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   udm.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/udm.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-udr/templates/configmap.yaml
+++ b/charts/open5gs-udr/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   udr.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/udr.yaml") . | indent 4 }}
   {{- end }}

--- a/charts/open5gs-upf/templates/configmap.yaml
+++ b/charts/open5gs-upf/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   upf.yaml: |
     {{- if .Values.customOpen5gsConfig }}
-    {{ toYaml .Values.customOpen5gsConfig }}
+    {{ toYaml .Values.customOpen5gsConfig | nindent 4 }}
     {{- else }}
 {{ tpl (.Files.Get "resources/config/upf.yaml") . | indent 4 }}
   {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

bug


#### What this PR does / why we need it:

fixed indentation of helm configMap with applied values in case of customOpen5gsConfig

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
