### PR TITLE
aligned to open5gs version 2.7.2 and chart version bump

### DIFF
--- a/charts/open5gs-amf/Chart.yaml
+++ b/charts/open5gs-amf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs AMF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-amf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-amf/values.yaml
+++ b/charts/open5gs-amf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-ausf/Chart.yaml
+++ b/charts/open5gs-ausf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs AUSF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-ausf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-ausf/values.yaml
+++ b/charts/open5gs-ausf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-bsf/Chart.yaml
+++ b/charts/open5gs-bsf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs BSF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-bsf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-bsf/values.yaml
+++ b/charts/open5gs-bsf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-hss/Chart.yaml
+++ b/charts/open5gs-hss/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs HSS service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-hss
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-hss/values.yaml
+++ b/charts/open5gs-hss/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-mme/Chart.yaml
+++ b/charts/open5gs-mme/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs MME service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-mme
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-mme/values.yaml
+++ b/charts/open5gs-mme/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs NRF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nrf/values.yaml
+++ b/charts/open5gs-nrf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-nssf/Chart.yaml
+++ b/charts/open5gs-nssf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs NSSF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nssf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nssf/values.yaml
+++ b/charts/open5gs-nssf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-pcf/Chart.yaml
+++ b/charts/open5gs-pcf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs PCF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcf/values.yaml
+++ b/charts/open5gs-pcf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-pcrf/Chart.yaml
+++ b/charts/open5gs-pcrf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs PCRF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcrf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcrf/values.yaml
+++ b/charts/open5gs-pcrf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-scp/Chart.yaml
+++ b/charts/open5gs-scp/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs scp service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-scp
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-scp/values.yaml
+++ b/charts/open5gs-scp/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-sgwc/Chart.yaml
+++ b/charts/open5gs-sgwc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs SGWC service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwc
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwc/values.yaml
+++ b/charts/open5gs-sgwc/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-sgwu/Chart.yaml
+++ b/charts/open5gs-sgwu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs SGWU service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwu
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-sgwu/values.yaml
+++ b/charts/open5gs-sgwu/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-smf/Chart.yaml
+++ b/charts/open5gs-smf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs SMF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-smf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-smf/values.yaml
+++ b/charts/open5gs-smf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-udm/Chart.yaml
+++ b/charts/open5gs-udm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs UDM service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udm
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udm/values.yaml
+++ b/charts/open5gs-udm/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-udr/Chart.yaml
+++ b/charts/open5gs-udr/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs UDR service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udr
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udr/values.yaml
+++ b/charts/open5gs-udr/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-upf/Chart.yaml
+++ b/charts/open5gs-upf/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs UPF service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-upf
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-upf/values.yaml
+++ b/charts/open5gs-upf/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs-webui/Chart.yaml
+++ b/charts/open5gs-webui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs WebUI service on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -12,7 +12,7 @@ maintainers:
 - email: avrodriguez@gradiant.org
   name: avrodriguez
 name: open5gs-webui
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-webui/values.yaml
+++ b/charts/open5gs-webui/values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: gradiant/open5gs-webui
-  tag: "2.7.1"
+  tag: "2.7.2"
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.1"
+appVersion: "2.7.2"
 description: >
   Helm chart to deploy Open5gs services on Kubernetes.
 home: https://github.com/gradiant/5g-charts
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.2.4
+version: 2.2.5
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -29,87 +29,87 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: open5gs-amf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-amf
     condition: amf.enabled
     alias: amf
   - name: open5gs-ausf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-ausf
     condition: ausf.enabled
     alias: ausf
   - name: open5gs-bsf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-bsf
     condition: bsf.enabled
     alias: bsf
   - name: open5gs-hss
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-hss
     condition: hss.enabled
     alias: hss
   - name: open5gs-mme
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-mme
     condition: mme.enabled
     alias: mme
   - name: open5gs-nrf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-nrf
     condition: nrf.enabled
     alias: nrf
   - name: open5gs-nssf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-nssf
     condition: nssf.enabled
     alias: nssf
   - name: open5gs-pcf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-pcf
     condition: pcf.enabled
     alias: pcf
   - name: open5gs-pcrf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-pcrf
     condition: pcrf.enabled
     alias: pcrf
   - name: open5gs-scp
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-scp
     condition: scp.enabled
     alias: scp
   - name: open5gs-sgwc
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-sgwc
     condition: sgwc.enabled
     alias: sgwc
   - name: open5gs-sgwu
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-sgwu
     condition: sgwu.enabled
     alias: sgwu
   - name: open5gs-smf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-smf
     condition: smf.enabled
     alias: smf
   - name: open5gs-udm
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-udm
     condition: udm.enabled
     alias: udm
   - name: open5gs-udr
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-udr
     condition: udr.enabled
     alias: udr
   - name: open5gs-upf
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-upf
     condition: upf.enabled
     alias: upf
   - name: open5gs-webui
-    version: ~2.2.4
+    version: ~2.2.5
     repository: file://../open5gs-webui
     condition: webui.enabled
     alias: webui


### PR DESCRIPTION
#### What type of PR is this?

version alignment to open5gs 2.7.2

#### What this PR does / why we need it:

align to version and regenerate main open5gs helm chart

#### Which issue(s) this PR fixes:

align to open5gs 2.7.2 version
insert "https://github.com/Gradiant/5g-charts/pull/188" into main package

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
