### PR TITLE
updates release.yml with ORAS dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up ORAS
+        uses: oras-project/setup-oras@v1
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
ORAS is not installed after security update. Using this action, ORAS is set up in the action to be used.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
