### PR TITLE
Add metadata labels to all HorizontalPodAutoscaler resources

### DIFF
--- a/charts/free5gc-amf/templates/hpa.yaml
+++ b/charts/free5gc-amf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-ausf/templates/hpa.yaml
+++ b/charts/free5gc-ausf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-chf/templates/hpa.yaml
+++ b/charts/free5gc-chf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-nrf/templates/hpa.yaml
+++ b/charts/free5gc-nrf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-nssf/templates/hpa.yaml
+++ b/charts/free5gc-nssf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-pcf/templates/hpa.yaml
+++ b/charts/free5gc-pcf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-smf/templates/hpa.yaml
+++ b/charts/free5gc-smf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-udm/templates/hpa.yaml
+++ b/charts/free5gc-udm/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-udr/templates/hpa.yaml
+++ b/charts/free5gc-udr/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-upf/templates/hpa.yaml
+++ b/charts/free5gc-upf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/free5gc-webui/templates/hpa.yaml
+++ b/charts/free5gc-webui/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-amf/templates/hpa.yaml
+++ b/charts/open5gs-amf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-ausf/templates/hpa.yaml
+++ b/charts/open5gs-ausf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-bsf/templates/hpa.yaml
+++ b/charts/open5gs-bsf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-hss/templates/hpa.yaml
+++ b/charts/open5gs-hss/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-mme/templates/hpa.yaml
+++ b/charts/open5gs-mme/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-nrf/templates/hpa.yaml
+++ b/charts/open5gs-nrf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-nssf/templates/hpa.yaml
+++ b/charts/open5gs-nssf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-pcf/templates/hpa.yaml
+++ b/charts/open5gs-pcf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-pcrf/templates/hpa.yaml
+++ b/charts/open5gs-pcrf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-scp/templates/hpa.yaml
+++ b/charts/open5gs-scp/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-sgwc/templates/hpa.yaml
+++ b/charts/open5gs-sgwc/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-sgwu/templates/hpa.yaml
+++ b/charts/open5gs-sgwu/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-smf/templates/hpa.yaml
+++ b/charts/open5gs-smf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-udm/templates/hpa.yaml
+++ b/charts/open5gs-udm/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-udr/templates/hpa.yaml
+++ b/charts/open5gs-udr/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/open5gs-upf/templates/hpa.yaml
+++ b/charts/open5gs-upf/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/packetrusher/templates/hpa.yaml
+++ b/charts/packetrusher/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/srsran-5g-zmq/templates/hpa.yaml
+++ b/charts/srsran-5g-zmq/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/srsran-5g/templates/hpa.yaml
+++ b/charts/srsran-5g/templates/hpa.yaml
@@ -2,6 +2,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:

--- a/charts/ueransim-gnb/templates/gnb-hpa.yaml
+++ b/charts/ueransim-gnb/templates/gnb-hpa.yaml
@@ -3,6 +3,10 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   maxReplicas: 1
   scaleTargetRef:


### PR DESCRIPTION
#### What type of PR is this?

feature / metadata improvement

#### What this PR does / why we need it:

In charts/, all Kubernetes resources have metadata labels defined, except for all HorizontalPodAutoscaler resources, as illustrated in the following architecture diagrams generated with KubeDiagrams:

![gradiant-free5gc-original](https://github.com/user-attachments/assets/20a1b254-fed2-4d19-9068-c34c7d3a78c5)

![gradiant-open5gs-original](https://github.com/user-attachments/assets/ca4b3f42-0d7d-4589-8f7c-cc5708f99939)

This should be an oversight, shouldn't it?

This PR adds metadata labels to all HorizontalPodAutoscaler resources, as illustrated in the following architecture diagrams generated with KubeDiagrams:

![gradiant-free5gc](https://github.com/user-attachments/assets/dc7dbeb3-29b7-455a-8cd1-1da78497609d)

![gradiant-open5gs](https://github.com/user-attachments/assets/1b9f3962-02cf-4af7-872e-51fd07686a41)

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This PR does not change anything on how charts behave. This PR only fixes metadata labels.

#### Does this PR introduce a user-facing change?

No

#### Does this PR introduce new external dependencies?

No

#### Additional documentation:

```docs

```
