### PR TITLE
add handling of advertise configuration option in ConfigMaps

### DIFF
--- a/charts/open5gs-amf/Chart.yaml
+++ b/charts/open5gs-amf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-amf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-amf/resources/config/amf.yaml
+++ b/charts/open5gs-amf/resources/config/amf.yaml
@@ -13,8 +13,10 @@ amf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-amf/resources/config/amf.yaml
+++ b/charts/open5gs-amf/resources/config/amf.yaml
@@ -13,6 +13,9 @@ amf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-amf/values.schema.json
+++ b/charts/open5gs-amf/values.schema.json
@@ -123,7 +123,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 },

--- a/charts/open5gs-amf/values.yaml
+++ b/charts/open5gs-amf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-ausf/Chart.yaml
+++ b/charts/open5gs-ausf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-ausf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-ausf/resources/config/ausf.yaml
+++ b/charts/open5gs-ausf/resources/config/ausf.yaml
@@ -14,6 +14,9 @@ ausf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-ausf/resources/config/ausf.yaml
+++ b/charts/open5gs-ausf/resources/config/ausf.yaml
@@ -14,8 +14,10 @@ ausf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-ausf/values.schema.json
+++ b/charts/open5gs-ausf/values.schema.json
@@ -57,7 +57,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-ausf/values.yaml
+++ b/charts/open5gs-ausf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-bsf/Chart.yaml
+++ b/charts/open5gs-bsf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-bsf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-bsf/resources/config/bsf.yaml
+++ b/charts/open5gs-bsf/resources/config/bsf.yaml
@@ -14,8 +14,10 @@ bsf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-bsf/resources/config/bsf.yaml
+++ b/charts/open5gs-bsf/resources/config/bsf.yaml
@@ -14,6 +14,9 @@ bsf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-bsf/values.schema.json
+++ b/charts/open5gs-bsf/values.schema.json
@@ -54,7 +54,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-bsf/values.yaml
+++ b/charts/open5gs-bsf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nrf/resources/config/nrf.yaml
+++ b/charts/open5gs-nrf/resources/config/nrf.yaml
@@ -16,8 +16,10 @@ nrf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
 
 ################################################################################

--- a/charts/open5gs-nrf/resources/config/nrf.yaml
+++ b/charts/open5gs-nrf/resources/config/nrf.yaml
@@ -16,6 +16,9 @@ nrf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
 
 ################################################################################
 # SBI Server

--- a/charts/open5gs-nrf/values.schema.json
+++ b/charts/open5gs-nrf/values.schema.json
@@ -22,6 +22,26 @@
             "properties": {
                 "logLevel": {
                     "type": "string"
+                },
+                "sbi": {
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                        }
+                    }
                 }
             }
         },

--- a/charts/open5gs-nrf/values.yaml
+++ b/charts/open5gs-nrf/values.yaml
@@ -77,6 +77,9 @@ image:
 
 config:
   logLevel: info
+  # advertise: provide custom SBI address to be advertised to NRF
+  sbi:
+    server:
   servingList:
     - plmn_id:
         mcc: 999

--- a/charts/open5gs-nrf/values.yaml
+++ b/charts/open5gs-nrf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
   servingList:
     - plmn_id:
         mcc: 999

--- a/charts/open5gs-nssf/Chart.yaml
+++ b/charts/open5gs-nssf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nssf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-nssf/resources/config/nssf.yaml
+++ b/charts/open5gs-nssf/resources/config/nssf.yaml
@@ -13,6 +13,9 @@ nssf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-nssf/resources/config/nssf.yaml
+++ b/charts/open5gs-nssf/resources/config/nssf.yaml
@@ -13,8 +13,10 @@ nssf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-nssf/values.schema.json
+++ b/charts/open5gs-nssf/values.schema.json
@@ -72,6 +72,21 @@
                                     }
                                 }
                             }
+                        },
+                        "server": {
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-nssf/values.yaml
+++ b/charts/open5gs-nssf/values.yaml
@@ -77,8 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
+    server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-pcf/Chart.yaml
+++ b/charts/open5gs-pcf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-pcf/resources/config/pcf.yaml
+++ b/charts/open5gs-pcf/resources/config/pcf.yaml
@@ -13,8 +13,10 @@ pcf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-pcf/resources/config/pcf.yaml
+++ b/charts/open5gs-pcf/resources/config/pcf.yaml
@@ -13,6 +13,9 @@ pcf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-pcf/values.schema.json
+++ b/charts/open5gs-pcf/values.schema.json
@@ -57,7 +57,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-pcf/values.yaml
+++ b/charts/open5gs-pcf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-scp/Chart.yaml
+++ b/charts/open5gs-scp/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-scp
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-scp/resources/config/scp.yaml
+++ b/charts/open5gs-scp/resources/config/scp.yaml
@@ -13,6 +13,9 @@ scp:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-scp/resources/config/scp.yaml
+++ b/charts/open5gs-scp/resources/config/scp.yaml
@@ -13,8 +13,10 @@ scp:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-scp/values.schema.json
+++ b/charts/open5gs-scp/values.schema.json
@@ -43,7 +43,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-scp/values.yaml
+++ b/charts/open5gs-scp/values.yaml
@@ -77,6 +77,7 @@ image:
 
 config:
   logLevel: info
+  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
     client:

--- a/charts/open5gs-scp/values.yaml
+++ b/charts/open5gs-scp/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: true

--- a/charts/open5gs-smf/Chart.yaml
+++ b/charts/open5gs-smf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-smf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-smf/resources/config/smf.yaml
+++ b/charts/open5gs-smf/resources/config/smf.yaml
@@ -14,8 +14,10 @@ smf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-smf/resources/config/smf.yaml
+++ b/charts/open5gs-smf/resources/config/smf.yaml
@@ -14,6 +14,9 @@ smf:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-smf/values.schema.json
+++ b/charts/open5gs-smf/values.schema.json
@@ -85,7 +85,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 },

--- a/charts/open5gs-smf/values.yaml
+++ b/charts/open5gs-smf/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-udm/Chart.yaml
+++ b/charts/open5gs-udm/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udm
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udm/resources/config/udm.yaml
+++ b/charts/open5gs-udm/resources/config/udm.yaml
@@ -32,6 +32,9 @@ udm:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-udm/resources/config/udm.yaml
+++ b/charts/open5gs-udm/resources/config/udm.yaml
@@ -32,8 +32,10 @@ udm:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-udm/values.schema.json
+++ b/charts/open5gs-udm/values.schema.json
@@ -57,7 +57,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-udm/values.yaml
+++ b/charts/open5gs-udm/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs-udr/Chart.yaml
+++ b/charts/open5gs-udr/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udr
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-udr/resources/config/udr.yaml
+++ b/charts/open5gs-udr/resources/config/udr.yaml
@@ -13,6 +13,9 @@ udr:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
+      {{- if .Values.config.advertise }}
+      advertise: {{ .Values.config.advertise }}
+      {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}
       nrf:

--- a/charts/open5gs-udr/resources/config/udr.yaml
+++ b/charts/open5gs-udr/resources/config/udr.yaml
@@ -13,8 +13,10 @@ udr:
     server:
     - dev: eth0
       port: {{ .Values.containerPorts.sbi }}
-      {{- if .Values.config.advertise }}
-      advertise: {{ .Values.config.advertise }}
+      {{- with .Values.config.sbi.server }}
+      {{- if .advertise }}
+      advertise: {{ .advertise }}
+      {{- end }}
       {{- end }}
     client:
       {{- if .Values.config.sbi.client.nrf.enabled }}

--- a/charts/open5gs-udr/values.schema.json
+++ b/charts/open5gs-udr/values.schema.json
@@ -57,7 +57,19 @@
                             }
                         },
                         "server": {
-                            "type": "null"
+                        "type": ["null", "object"],
+                        "properties": {
+                            "dev": {
+                            "type": "string"
+                            },
+                            "address": {
+                            "type": "string"
+                            },
+                            "advertise": {
+                            "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
                         }
                     }
                 }

--- a/charts/open5gs-udr/values.yaml
+++ b/charts/open5gs-udr/values.yaml
@@ -77,9 +77,9 @@ image:
 
 config:
   logLevel: info
-  # advertise: provide custom SBI address to be advertised to NRF
   sbi:
     server:
+      # advertise: provide custom SBI address to be advertised to NRF
     client:
       nrf:
         enabled: false

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -29,17 +29,17 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: open5gs-amf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-amf
     condition: amf.enabled
     alias: amf
   - name: open5gs-ausf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-ausf
     condition: ausf.enabled
     alias: ausf
   - name: open5gs-bsf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-bsf
     condition: bsf.enabled
     alias: bsf
@@ -54,17 +54,17 @@ dependencies:
     condition: mme.enabled
     alias: mme
   - name: open5gs-nrf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-nrf
     condition: nrf.enabled
     alias: nrf
   - name: open5gs-nssf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-nssf
     condition: nssf.enabled
     alias: nssf
   - name: open5gs-pcf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-pcf
     condition: pcf.enabled
     alias: pcf
@@ -74,7 +74,7 @@ dependencies:
     condition: pcrf.enabled
     alias: pcrf
   - name: open5gs-scp
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-scp
     condition: scp.enabled
     alias: scp
@@ -89,17 +89,17 @@ dependencies:
     condition: sgwu.enabled
     alias: sgwu
   - name: open5gs-smf
-    version: ~2.2.7
+    version: ~2.3.0
     repository: file://../open5gs-smf
     condition: smf.enabled
     alias: smf
   - name: open5gs-udm
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-udm
     condition: udm.enabled
     alias: udm
   - name: open5gs-udr
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-udr
     condition: udr.enabled
     alias: udr


### PR DESCRIPTION
advertise configuration field was alerady foreseen in open5gs values of different NF.
However, it was not correctly mapped in each related ConfigMap yaml file