### PR TITLE
fixes temporarily pull error of mongodb image for open5gs webui helm

### DIFF
--- a/charts/open5gs-webui/Chart.yaml
+++ b/charts/open5gs-webui/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 - email: avrodriguez@gradiant.org
   name: avrodriguez
 name: open5gs-webui
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:

--- a/charts/open5gs-webui/templates/deployment.yaml
+++ b/charts/open5gs-webui/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init
-          image: bitnami/mongodb:4.4.1-debian-10-r39
+          image: bitnamilegacy/mongodb:4.4.1
           env:
           - name: DB_URI
             {{- if .Values.dbURI }}

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.3.1
+version: 2.3.2
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -114,7 +114,7 @@ dependencies:
     condition: upf.enabled
     alias: upf
   - name: open5gs-webui
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-webui
     condition: webui.enabled
     alias: webui


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
bug
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
fixes temporarily pull error of mongodb image for open5gs webui helm due to bitnami changes

#### Which issue(s) this PR fixes:
https://github.com/Gradiant/5g-charts/issues/225

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
