### PR TITLE
adds artifact hub identification to free5gc charts

### DIFF
--- a/charts/free5gc-amf/Chart.yaml
+++ b/charts/free5gc-amf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-amf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-amf/README.md
+++ b/charts/free5gc-amf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC AMF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-amf/artifacthub-repo.yml
+++ b/charts/free5gc-amf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 927c77a2-a322-4b7a-b4a7-73851387fd8c
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-ausf/Chart.yaml
+++ b/charts/free5gc-ausf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-ausf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-ausf/README.md
+++ b/charts/free5gc-ausf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC AUSF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-ausf/artifacthub-repo.yml
+++ b/charts/free5gc-ausf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: d4a49670-a379-4f33-ac3c-4c2bc9592f92
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-chf/Chart.yaml
+++ b/charts/free5gc-chf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-chf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-chf/README.md
+++ b/charts/free5gc-chf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC CHF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-chf/artifacthub-repo.yml
+++ b/charts/free5gc-chf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: db129377-35ba-4be2-96c0-f7835b270d41
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-nrf/Chart.yaml
+++ b/charts/free5gc-nrf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-nrf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-nrf/README.md
+++ b/charts/free5gc-nrf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC NRF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-nrf/artifacthub-repo.yml
+++ b/charts/free5gc-nrf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: c0e7367e-754f-4fed-b0c8-b10483673b76
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-nssf/Chart.yaml
+++ b/charts/free5gc-nssf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-nssf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-nssf/README.md
+++ b/charts/free5gc-nssf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC NSSF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-nssf/artifacthub-repo.yml
+++ b/charts/free5gc-nssf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: a31eb6ea-2211-42cc-8f7b-91b404ab50d3
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-pcf/Chart.yaml
+++ b/charts/free5gc-pcf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-pcf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-pcf/README.md
+++ b/charts/free5gc-pcf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC PCF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-pcf/artifacthub-repo.yml
+++ b/charts/free5gc-pcf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 4aea62ec-6900-4d4d-8bf5-73519bacd17a
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-smf/Chart.yaml
+++ b/charts/free5gc-smf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-smf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-smf/README.md
+++ b/charts/free5gc-smf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC SMF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-smf/artifacthub-repo.yml
+++ b/charts/free5gc-smf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: c7156567-e33b-417c-b54a-ceb5a73cff38
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-udm/Chart.yaml
+++ b/charts/free5gc-udm/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-udm
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-udm/README.md
+++ b/charts/free5gc-udm/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC UDM service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-udm/artifacthub-repo.yml
+++ b/charts/free5gc-udm/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 465f4752-a52b-4e0a-bc84-fbb1c8d879e5
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-udr/Chart.yaml
+++ b/charts/free5gc-udr/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-udr
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-udr/README.md
+++ b/charts/free5gc-udr/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC UDR service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-udr/artifacthub-repo.yml
+++ b/charts/free5gc-udr/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 056dfffe-278b-4f86-825d-8feff332ab41
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-upf/Chart.yaml
+++ b/charts/free5gc-upf/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-upf
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-upf/README.md
+++ b/charts/free5gc-upf/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC UPF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-upf/artifacthub-repo.yml
+++ b/charts/free5gc-upf/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 404a584f-0a32-4852-9b58-84b1636b2100
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc-webui/Chart.yaml
+++ b/charts/free5gc-webui/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc-webui
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,4 +24,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/free5gc-webui/README.md
+++ b/charts/free5gc-webui/README.md
@@ -21,7 +21,7 @@ Helm chart to deploy Free5GC WEBUI service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/free5gc-webui/artifacthub-repo.yml
+++ b/charts/free5gc-webui/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: e505f0a7-d035-4dfd-9558-2d039dea48b9
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/free5gc/Chart.yaml
+++ b/charts/free5gc/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
   - email: avrodriguez@gradiant.org
     name: avrodriguez
 name: free5gc
-version: 0.1.2
+version: 0.1.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,63 +24,63 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: free5gc-amf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-amf
     condition: amf.enabled
     alias: amf
   - name: free5gc-ausf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-ausf
     condition: ausf.enabled
     alias: ausf
   - name: free5gc-chf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-chf
     condition: chf.enabled
     alias: chf
   - name: free5gc-nrf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-nrf
     condition: nrf.enabled
     alias: nrf
   - name: free5gc-nssf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-nssf
     condition: nssf.enabled
     alias: nssf
   - name: free5gc-pcf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-pcf
     condition: pcf.enabled
     alias: pcf
   - name: free5gc-smf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-smf
     condition: smf.enabled
     alias: smf
   - name: free5gc-udm
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-udm
     condition: udm.enabled
     alias: udm
   - name: free5gc-udr
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-udr
     condition: udr.enabled
     alias: udr
   - name: free5gc-upf
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-upf
     condition: upf.enabled
     alias: upf
   - name: free5gc-webui
-    version: ~0.1.2
+    version: ~0.1.3
     repository: file://../free5gc-webui
     condition: webui.enabled
     alias: webui

--- a/charts/free5gc/README.md
+++ b/charts/free5gc/README.md
@@ -32,8 +32,8 @@ Helm chart to deploy Free5GC services on Kubernetes.
 | file://../free5gc-udr | udr(free5gc-udr) | ~0.1.0 |
 | file://../free5gc-upf | upf(free5gc-upf) | ~0.1.0 |
 | file://../free5gc-webui | webui(free5gc-webui) | ~0.1.0 |
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/free5gc/artifacthub-repo.yml
+++ b/charts/free5gc/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: 2113e0e9-8fad-4d6e-9594-8f371772aad1
+owners: # (optional, used to claim repository ownership)
+  - name: cgiraldo
+    email: cgiraldo@gradiant.org
+  - name: avrodriguez
+    email: avrodriguez@gradiant.org

--- a/charts/open5gs-amf/Chart.yaml
+++ b/charts/open5gs-amf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-amf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,4 +22,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-amf/README.md
+++ b/charts/open5gs-amf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs AMF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-ausf/Chart.yaml
+++ b/charts/open5gs-ausf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-ausf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-ausf/README.md
+++ b/charts/open5gs-ausf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs AUSF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-bsf/Chart.yaml
+++ b/charts/open5gs-bsf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-bsf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-bsf/README.md
+++ b/charts/open5gs-bsf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs BSF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-hss/Chart.yaml
+++ b/charts/open5gs-hss/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-hss
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -23,8 +23,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-hss/README.md
+++ b/charts/open5gs-hss/README.md
@@ -20,8 +20,8 @@ Helm chart to deploy Open5gs HSS service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs-mme/Chart.yaml
+++ b/charts/open5gs-mme/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-mme
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,4 +22,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-mme/README.md
+++ b/charts/open5gs-mme/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs MME service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-nrf/Chart.yaml
+++ b/charts/open5gs-nrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nrf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,4 +22,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-nrf/README.md
+++ b/charts/open5gs-nrf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs NRF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-nssf/Chart.yaml
+++ b/charts/open5gs-nssf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-nssf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-nssf/README.md
+++ b/charts/open5gs-nssf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs NSSF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-pcf/Chart.yaml
+++ b/charts/open5gs-pcf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,8 +22,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-pcf/README.md
+++ b/charts/open5gs-pcf/README.md
@@ -20,8 +20,8 @@ Helm chart to deploy Open5gs PCF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs-pcrf/Chart.yaml
+++ b/charts/open5gs-pcrf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-pcrf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -23,8 +23,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-pcrf/README.md
+++ b/charts/open5gs-pcrf/README.md
@@ -20,8 +20,8 @@ Helm chart to deploy Open5gs PCRF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs-scp/Chart.yaml
+++ b/charts/open5gs-scp/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-scp
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -23,8 +23,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-scp/README.md
+++ b/charts/open5gs-scp/README.md
@@ -20,8 +20,8 @@ Helm chart to deploy Open5gs scp service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs-sepp/Chart.yaml
+++ b/charts/open5gs-sepp/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sepp
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -23,4 +23,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-sepp/README.md
+++ b/charts/open5gs-sepp/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs SEPP service on Kubernetes without TLS.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-sgwc/Chart.yaml
+++ b/charts/open5gs-sgwc/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwc
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-sgwc/README.md
+++ b/charts/open5gs-sgwc/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs SGWC service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-sgwu/Chart.yaml
+++ b/charts/open5gs-sgwu/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-sgwu
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-sgwu/README.md
+++ b/charts/open5gs-sgwu/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs SGWU service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-smf/Chart.yaml
+++ b/charts/open5gs-smf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs-smf
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -21,4 +21,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-smf/README.md
+++ b/charts/open5gs-smf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs SMF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-udm/Chart.yaml
+++ b/charts/open5gs-udm/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udm
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,4 +22,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-udm/README.md
+++ b/charts/open5gs-udm/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs UDM service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-udr/Chart.yaml
+++ b/charts/open5gs-udr/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-udr
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,8 +22,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-udr/README.md
+++ b/charts/open5gs-udr/README.md
@@ -20,8 +20,8 @@ Helm chart to deploy Open5gs UDR service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs-upf/Chart.yaml
+++ b/charts/open5gs-upf/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
 - email: cgiraldo@gradiant.org
   name: cgiraldo
 name: open5gs-upf
-version: 2.2.9
+version: 2.3.0
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -22,4 +22,4 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x

--- a/charts/open5gs-upf/README.md
+++ b/charts/open5gs-upf/README.md
@@ -20,7 +20,7 @@ Helm chart to deploy Open5gs UPF service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/open5gs-webui/Chart.yaml
+++ b/charts/open5gs-webui/Chart.yaml
@@ -12,7 +12,7 @@ maintainers:
 - email: avrodriguez@gradiant.org
   name: avrodriguez
 name: open5gs-webui
-version: 2.3.0
+version: 2.3.1
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -24,8 +24,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled

--- a/charts/open5gs-webui/README.md
+++ b/charts/open5gs-webui/README.md
@@ -21,8 +21,8 @@ Helm chart to deploy Open5gs WebUI service on Kubernetes.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 

--- a/charts/open5gs/Chart.yaml
+++ b/charts/open5gs/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - email: cgiraldo@gradiant.org
     name: cgiraldo
 name: open5gs
-version: 2.3.2
+version: 2.3.3
 annotations:
   artifacthub.io/category: networking
 keywords:
@@ -23,98 +23,98 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: mongodb
-    version: ~12.1.19
+    version: ~18.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.enabled
   - name: open5gs-amf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-amf
     condition: amf.enabled
     alias: amf
   - name: open5gs-ausf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-ausf
     condition: ausf.enabled
     alias: ausf
   - name: open5gs-bsf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-bsf
     condition: bsf.enabled
     alias: bsf
   - name: open5gs-hss
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-hss
     condition: hss.enabled
     alias: hss
   - name: open5gs-mme
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-mme
     condition: mme.enabled
     alias: mme
   - name: open5gs-nrf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-nrf
     condition: nrf.enabled
     alias: nrf
   - name: open5gs-nssf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-nssf
     condition: nssf.enabled
     alias: nssf
   - name: open5gs-pcf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-pcf
     condition: pcf.enabled
     alias: pcf
   - name: open5gs-pcrf
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-pcrf
     condition: pcrf.enabled
     alias: pcrf
   - name: open5gs-scp
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-scp
     condition: scp.enabled
     alias: scp
   - name: open5gs-sepp
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-sepp
     condition: sepp.enabled
     alias: sepp
   - name: open5gs-sgwc
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-sgwc
     condition: sgwc.enabled
     alias: sgwc
   - name: open5gs-sgwu
-    version: ~2.2.9
+    version: ~2.3.0
     repository: file://../open5gs-sgwu
     condition: sgwu.enabled
     alias: sgwu
   - name: open5gs-smf
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-smf
     condition: smf.enabled
     alias: smf
   - name: open5gs-udm
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-udm
     condition: udm.enabled
     alias: udm
   - name: open5gs-udr
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-udr
     condition: udr.enabled
     alias: udr
   - name: open5gs-upf
-    version: ~2.2.7
+    version: ~2.3.0
     repository: file://../open5gs-upf
     condition: upf.enabled
     alias: upf
   - name: open5gs-webui
-    version: ~2.3.0
+    version: ~2.3.1
     repository: file://../open5gs-webui
     condition: webui.enabled
     alias: webui

--- a/charts/open5gs/README.md
+++ b/charts/open5gs/README.md
@@ -37,8 +37,8 @@ Helm chart to deploy Open5gs services on Kubernetes.
 | file://../open5gs-udr | udr(open5gs-udr) | ~2.1.0 |
 | file://../open5gs-upf | upf(open5gs-upf) | ~2.1.0 |
 | file://../open5gs-webui | webui(open5gs-webui) | ~2.1.0 |
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
-| https://charts.bitnami.com/bitnami | mongodb | ~12.1.19 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | mongodb | ~18.0.5 |
 
 ## Values
 


### PR DESCRIPTION
<!--
PR REQUIREMENTS

The chart version must be bumped in chart.yaml. Then the chart must be linted by running scripts/lint.sh
-->


#### What type of PR is this?
feature
<!-- 
bug
cleanup
documentation
feature
-->

#### What this PR does / why we need it:
adds artifact hub identification to free5gc charts

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?


#### Does this PR introduce new external dependencies?


#### Additional documentation:

```docs

```
